### PR TITLE
Add ps command to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update \
 && apt-get install --no-install-recommends -y \
   ntp \
   perl \
+  procps \
 && apt-get -y clean \
 && rm -rf /var/lib/apt/lists/*
 
@@ -14,4 +15,4 @@ RUN mkdir /usr/local/logicmonitor
 ADD collector /collector
 COPY ./startup.sh /startup.sh
 
-ENTRYPOINT ["/startup.sh"]
+CMD ["/startup.sh"]


### PR DESCRIPTION
The image currently does not start without the `ps` command installed, this remedies it.

It also changes from ENTRYPOINT to CMD to allow for easier debugging.