### PR TITLE
Removing beta warning from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 ## Overview
 Docker image capable of installing and running a LogicMonitor collector
 
-#### Note that this is beta functionality, and as such LogicMonitor support will not be able to assist in any issues that arise.  Instead, please create issues directly in this GitHub repository.
-
 ## Website
 http://www.logicmonitor.com
 


### PR DESCRIPTION
Since support for LM docker collector is no longer beta, beta notice in readme should be removed