### PR TITLE
Increased wait time on watchdog service to 3 min before marking pod unhealthy.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -45,7 +45,7 @@ watch_pid() {
         PID=$NEW_PID
       else
         PID_FAIL=$(($PID_FAIL+1))
-        if [ "$PID_FAIL" -ge 12 ]; then
+        if [ "$PID_FAIL" -ge 18 ]; then
           # we want to skip cleanup scripts since the collector failed unexpectedly
           echo -e "Watchdog crashed\nExiting"
           touch $UNCLEAN_SHUTDOWN_PATH


### PR DESCRIPTION
watchdog-timeout:  Merge pull request #7 in DEV/docker_lm_collector from DEV-62145-watch-pid-timeout to develop

* commit 'cb60158037cc52645d7495b79feff070d8de72a2':
  DEV-62145: Watchdog service is taking time more than 2 min to come up after upgrade, increasing timeout to 3 mins now