### PR TITLE
Sanitize return values for util.shell to str

### DIFF
--- a/collector/util.py
+++ b/collector/util.py
@@ -50,8 +50,9 @@ def shell(cmd, cwd=None):
              )
         stdout, stderr = p.communicate()
         result['code'] = p.returncode
-        result['stdout'] = stdout or ''
-        result['stderr'] = stderr or ''
+        # Python3 returns byte objects on stdout and stderr. Decode them to return str
+        result['stdout'] = stdout.decode("utf-8", errors="replace")
+        result['stderr'] = stderr.decode("utf-8", errors="replace")
 
     except:
         result['code'] = -1


### PR DESCRIPTION
Python3 subprocess.Popen returns bytes on stdout and stderr, and not str as Python2 did.
This results in a TypeError in collector.install_collector in case there are errors running `util.shell(install_cmd)`.

This commit fixes this issue by decoding stdout and stderr as UTF8. This results in the values being str again.